### PR TITLE
Replace `obj` in DocBlocks with class name.

### DIFF
--- a/framework/class-llms-unit-test-factory.php
+++ b/framework/class-llms-unit-test-factory.php
@@ -7,21 +7,21 @@ class LLMS_Unit_Test_Factory extends WP_UnitTest_Factory {
 	/**
 	 * LLMS_Unit_Test_Factory_For_Course
 	 *
-	 * @var obj
+	 * @var LLMS_Unit_Test_Factory_For_Course
 	 */
 	public $course;
 
 	/**
 	 * LLMS_Unit_Test_Factory_For_Instructor
 	 *
-	 * @var obj
+	 * @var LLMS_Unit_Test_Factory_For_Instructor
 	 */
 	public $instructor;
 
 	/**
 	 * LLMS_Unit_Test_Factory_For_Membership
 	 *
-	 * @var obj
+	 * @var LLMS_Unit_Test_Factory_For_Membership
 	 */
 	public $membership;
 
@@ -29,14 +29,14 @@ class LLMS_Unit_Test_Factory extends WP_UnitTest_Factory {
 	/**
 	 * LLMS_Unit_Test_Factory_For_Order
 	 *
-	 * @var obj
+	 * @var LLMS_Unit_Test_Factory_For_Order
 	 */
 	public $order;
 
 	/**
 	 * LLMS_Unit_Test_Factory_For_Student
 	 *
-	 * @var obj
+	 * @var LLMS_Unit_Test_Factory_For_Student
 	 */
 	public $student;
 

--- a/framework/class-llms-unit-test-util.php
+++ b/framework/class-llms-unit-test-util.php
@@ -4,6 +4,11 @@
  */
 class LLMS_Unit_Test_Util {
 
+	/**
+	 * @param object $obj
+	 * @return ReflectionClass
+	 * @throws ReflectionException
+	 */
 	private static function get_class( $obj ) {
 
 		return new ReflectionClass( $obj );
@@ -12,10 +17,12 @@ class LLMS_Unit_Test_Util {
 
 	/**
 	 * Call a method (private or protected)
-	 * @param   obj $obj Instantiated class instance
-	 * @param   string $name Name of the method to call
-	 * @param   array $args arguments to pass to the method
-	 * @return  mixed
+	 *
+	 * @param object $obj  Instantiated class instance
+	 * @param string $name Name of the method to call
+	 * @param array  $args arguments to pass to the method
+	 * @return mixed
+	 * @throws ReflectionException
 	 */
 	public static function call_method( $obj, $name, array $args = array() ) {
 
@@ -26,9 +33,11 @@ class LLMS_Unit_Test_Util {
 
 	/**
 	 * Alias of LLMS_Unit_Test_Utilities::get_private_method()
-	 * @param   obj $obj Instantiated class instance
-	 * @param   string $name Name of the method to call
-	 * @return  ReflectionMethod
+	 *
+	 * @param object $obj  Instantiated class instance
+	 * @param string $name Name of the method to call
+	 * @return ReflectionMethod
+	 * @throws ReflectionException
 	 */
 	public static function get_protected_method( $obj, $name ) {
 
@@ -38,9 +47,11 @@ class LLMS_Unit_Test_Util {
 
 	/**
 	 * Retrieve a testable private/protected class method
-	 * @param   obj $obj Instantiated class instance
-	 * @param   string $name Name of the method to call
-	 * @return  ReflectionMethod
+	 *
+	 * @param object $obj  Instantiated class instance
+	 * @param string $name Name of the method to call
+	 * @return ReflectionMethod
+	 * @throws ReflectionException
 	 */
 	public static function get_private_method( $obj, $name ) {
 
@@ -51,6 +62,12 @@ class LLMS_Unit_Test_Util {
 
 	}
 
+	/**
+	 * @param object $obj
+	 * @param string $name
+	 * @return ReflectionProperty
+	 * @throws ReflectionException
+	 */
 	public static function get_private_property( $obj, $name ) {
 
 		$class = self::get_class( $obj );
@@ -59,6 +76,12 @@ class LLMS_Unit_Test_Util {
 
 	}
 
+	/**
+	 * @param object $obj
+	 * @param string $name
+	 * @param mixed $val
+	 * @throws ReflectionException
+	 */
 	public static function set_private_property( $obj, $name, $val ) {
 
 		$prop = self::get_private_property( $obj, $name );

--- a/framework/factory/class-llms-unit-test-factory-for-instructor.php
+++ b/framework/factory/class-llms-unit-test-factory-for-instructor.php
@@ -8,7 +8,7 @@ class LLMS_Unit_Test_Factory_For_Instructor extends WP_UnitTest_Factory_For_User
 	 * This is essentially the WP Core User Factory except it creates users with the "Instructor" role
 	 * and Returns an LLMS_Student object with gets
 	 *
-	 * @param   obj $factory  Global Factory.
+	 * @param object $factory Global Factory.
 	 */
 	public function __construct( $factory = null ) {
 		parent::__construct( $factory );
@@ -24,7 +24,7 @@ class LLMS_Unit_Test_Factory_For_Instructor extends WP_UnitTest_Factory_For_User
 	 * Retrieve student by ID
 	 *
 	 * @param   int   $user_id WP User ID.
-	 * @return  obj
+	 * @return  LLMS_Instructor
 	 */
 	public function get_object_by_id( $user_id ) {
 		return new LLMS_Instructor( $user_id );

--- a/framework/factory/class-llms-unit-test-factory-for-student.php
+++ b/framework/factory/class-llms-unit-test-factory-for-student.php
@@ -8,7 +8,7 @@ class LLMS_Unit_Test_Factory_For_Student extends WP_UnitTest_Factory_For_User {
 	 * This is essentially the WP Core User Factory except it creates users with the "Student" role
 	 * and Returns an LLMS_Student object with gets
 	 *
-	 * @param   obj $factory  Global Factory.
+	 * @param object $factory Global Factory.
 	 */
 	public function __construct( $factory = null ) {
 		parent::__construct( $factory );
@@ -57,7 +57,7 @@ class LLMS_Unit_Test_Factory_For_Student extends WP_UnitTest_Factory_For_User {
 	 * Retrieve student by ID
 	 *
 	 * @param   int   $user_id WP User ID.
-	 * @return  obj
+	 * @return  LLMS_Student
 	 */
 	public function get_object_by_id( $user_id ) {
 		return new LLMS_Student( $user_id );

--- a/framework/traits/trait-llms-unit-test-assertions-wp-error.php
+++ b/framework/traits/trait-llms-unit-test-assertions-wp-error.php
@@ -10,7 +10,7 @@ trait LLMS_Unit_Test_Assertions_WP_Error {
 	/**
 	 * Assert that a give object is a WP_Error
 	 *
-	 * @param   obj    $wp_err WP_Error.
+	 * @param   WP_Error $wp_err
 	 * @return  void
 	 * @since   1.2.1
 	 * @version 1.3.0
@@ -25,7 +25,7 @@ trait LLMS_Unit_Test_Assertions_WP_Error {
 	 * Arrest that a given object has an expected WP_Error code.
 	 *
 	 * @param   string    $expected expected error code
-	 * @param   obj    $wp_err WP_Error.
+	 * @param   WP_Error $wp_err
 	 * @return  void
 	 * @since   1.2.1
 	 * @version 1.3.0


### PR DESCRIPTION
In PHPDoc DocBlocks, the type should be the class name(s) if known or `object` for undetermined class.