### PR TITLE
Fix issue with membership's post property names.

### DIFF
--- a/framework/factory/class-llms-unit-test-factory-for-membership.php
+++ b/framework/factory/class-llms-unit-test-factory-for-membership.php
@@ -5,10 +5,10 @@ class LLMS_Unit_Test_Factory_For_Membership extends WP_UnitTest_Factory_For_Post
 	public function __construct( $factory = null ) {
 		parent::__construct( $factory );
 		$this->default_generation_definitions = array(
-			'status'  => 'publish',
-			'title'   => new WP_UnitTest_Generator_Sequence( 'Membership title %s' ),
-			'content' => new WP_UnitTest_Generator_Sequence( 'Membership content %s' ),
-			'excerpt' => new WP_UnitTest_Generator_Sequence( 'Membership excerpt %s' ),
+			'post_status'  => 'publish',
+			'post_title'   => new WP_UnitTest_Generator_Sequence( 'Membership title %s' ),
+			'post_content' => new WP_UnitTest_Generator_Sequence( 'Membership content %s' ),
+			'post_excerpt' => new WP_UnitTest_Generator_Sequence( 'Membership excerpt %s' ),
 			'post_type' => 'llms_membership'
 		);
 	}


### PR DESCRIPTION
Because this class does not override `WP_UnitTest_Factory_For_Post->create_object()`, the keys in `$this->default_generation_definitions()` should be the same as used in `wp_insert_post()`.
 See [WP_UnitTest_Factory_For_Post ](https://github.com/WordPress/wordpress-develop/blob/3cd121d5d7c6cae9adb2e915532c9bfb927a373b/tests/phpunit/includes/factory/class-wp-unittest-factory-for-post.php#L18).