### PR TITLE
Add `factory` property declaration.

### DIFF
--- a/framework/traits/trait-llms-unit-test-case-base.php
+++ b/framework/traits/trait-llms-unit-test-case-base.php
@@ -18,7 +18,7 @@ trait LLMS_Unit_Test_Case_Base {
 	/**
 	 * @var LLMS_Unit_Test_Factory
 	 */
-	public $factory;
+	protected $factory;
 
 	/**
 	 * Setup the test case.

--- a/framework/traits/trait-llms-unit-test-case-base.php
+++ b/framework/traits/trait-llms-unit-test-case-base.php
@@ -16,6 +16,11 @@ trait LLMS_Unit_Test_Case_Base {
 	use LLMS_Unit_Test_Mock_Requests;
 
 	/**
+	 * @var LLMS_Unit_Test_Factory
+	 */
+	public $factory;
+
+	/**
 	 * Setup the test case.
 	 *
 	 * @since 1.6.0


### PR DESCRIPTION
The property declaration and DocBlock helps IDEs and humans know what is stored in this formally dynamically created property.