### PR TITLE
Add ability to get values from static properties.

### DIFF
--- a/framework/class-llms-unit-test-util.php
+++ b/framework/class-llms-unit-test-util.php
@@ -81,16 +81,17 @@ class LLMS_Unit_Test_Util {
 	 * Get the value of a private property.
 	 *
 	 * @since 1.11.0
+	 * @since [version] Add ability to get values from static properties.
 	 *
-	 * @param object $obj Object.
-	 * @param string $name Property name.
+	 * @param object|string $obj  Object. String is allowed if the property is static.
+	 * @param string        $name Property name.
 	 * @return mixed
 	 */
 	public static function get_private_property_value( $obj, $name ) {
 
 		$prop = self::get_private_property( $obj, $name );
 		$prop->setAccessible( true );
-		return $prop->getValue( $obj );
+		return $prop->isStatic() ? $prop->getValue() : $prop->getValue( $obj );
 
 	}
 


### PR DESCRIPTION
## Description
Added an ability to `LLMS_Unit_Test_Util::get_private_property_value()` that allows it to retrieve values from private/protected static properties.

## How has this been tested?
I temporarily modified `LLMS_Test_Singleton_Trait` and gave the method:
* an object and a non-static property
* an object and a static property
* a string and a static property

## Types of changes
Enhancement.

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->
