### PR TITLE
Revert yoast/phpunit-polyfills commits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
   ],
   "require": {
     "php": "^7.2 || ^8.0",
+    "phpunit/phpunit": "^7.5",
     "wp-cli/wp-cli-tests": "^3.0.15",
     "wp-cli/extension-command": "^2.1.0",
     "yoast/phpunit-polyfills": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     "php": "^7.2 || ^8.0",
     "phpunit/phpunit": "^7.5",
     "wp-cli/wp-cli-tests": "^3.0.15",
-    "wp-cli/extension-command": "^2.1.0",
-    "yoast/phpunit-polyfills": "^1.0"
+    "wp-cli/extension-command": "^2.1.0"
   },
   "bin": [
     "bin/llms-tests",

--- a/framework/class-llms-rest-unit-test-case.php
+++ b/framework/class-llms-rest-unit-test-case.php
@@ -7,8 +7,8 @@
 class LLMS_REST_Unit_Test_Case extends WP_UnitTestCase {
 
 	use LLMS_Unit_Test_Case_Base {
-		set_up as base_set_up;
-		tear_down as base_tear_down;
+		setUp as baseSetUp;
+		tearDown as baseTearDown;
 	}
 	use LLMS_Unit_Test_Assertions_REST_Responses;
 
@@ -28,9 +28,9 @@ class LLMS_REST_Unit_Test_Case extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function set_up() {
+	public function setUp() {
 
-		$this::base_set_up();
+		$this::baseSetUp();
 		do_action( 'rest_api_init' );
 		$this->server = rest_get_server();
 
@@ -43,9 +43,9 @@ class LLMS_REST_Unit_Test_Case extends WP_UnitTestCase {
 	 *
 	 * @return  void
 	 */
-	public function tear_down() {
+	public function tearDown() {
 
-		$this::base_tear_down();
+		$this::baseTearDown();
 
 		global $wp_rest_server;
 		unset( $this->server );

--- a/framework/traits/trait-llms-unit-test-case-base.php
+++ b/framework/traits/trait-llms-unit-test-case-base.php
@@ -47,13 +47,12 @@ trait LLMS_Unit_Test_Case_Base {
 	 * @since 1.6.0
 	 * @since 1.7.0 Initailize the `$cookies` property.
 	 * @since 1.14.0 Add access to logs class.
-	 * @since 2.0.0 Renamed & use set_up() in favor of setUp().
 	 *
 	 * @return void
 	 */
-	public function set_up() {
+	public function setUp() {
 
-		parent::set_up();
+		parent::setUp();
 		$this->cookies = LLMS_Tests_Cookies::instance();
 		$this->factory = new LLMS_Unit_Test_Factory();
 		$this->logs    = new LLMS_Tests_Logs();
@@ -131,13 +130,12 @@ trait LLMS_Unit_Test_Case_Base {
 	 * @since 1.7.0 Unset all cookies set by LLMS_Tests_Cookies and reset the expected response of all cookie sets to `true`.
 	 * @since 1.7.2 Clear LifterLMS notices and reset `$_SERVER['REQUEST_URI']` global.
 	 * @since 1.14.0 Clear logs.
- 	 * @since 2.0.0 Renamed & use tear_down() in favor of tearDown().
 	 *
 	 * @return void
 	 */
-	public function tear_down() {
+	public function tearDown() {
 
-		parent::tear_down();
+		parent::tearDown();
 
 		// Reset mocked data.
 		llms_tests_reset_current_time();


### PR DESCRIPTION
Revert these commits until the WP Develop tests environment is backported to WP versions <= 5.8

Until then we cannot really use the yoast lib unless we run the tests lib off the trunk directly which will be more time-consuming and problematic than waiting