### PR TITLE
Fixing error when building main docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor/
+.idea

--- a/docker/scripts/container-command.sh
+++ b/docker/scripts/container-command.sh
@@ -24,7 +24,7 @@ fi
 which netcat && echo "Already installed: skipping apt dependency installation."
 if ! $( which netcat ); then
 	apt update
-	apt -y install netcat mariadb-client
+	apt -y install netcat-traditional mariadb-client
 fi
 
 # Ensure DB is ready before proceeding.


### PR DESCRIPTION
## Description

When running locally, there is an error installing `netcat` to verify the DB is ready. From a thread there's now two `netcat` related packages, so using `netcat-traditional` instead can work.

## How has this been tested?

Manually, would need to update and try via `lifterlms` repo afterwords.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

